### PR TITLE
Add workflow to test latest cmake version nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,29 @@
+on:
+  schedule:
+    - cron:  '* 0 * * *'
+  workflow_dispatch:
+
+
+jobs:
+  latest_version:
+    runs-on: ${{ matrix.os }}
+    name: Test latest version
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Setup cmake
+      uses: ./
+      id: setup
+      with:
+        cmake-version: ''
+
+    - name: Run cmake --version
+      shell: bash
+      run: |
+        VERSION=`cmake --version`
+        echo $VERSION


### PR DESCRIPTION
This should hopefully catch problems with the action arising from
changes to how the CMake packages are provided.